### PR TITLE
Fix errors in find_by_dt/find_by_cls

### DIFF
--- a/skadi/engine/world.py
+++ b/skadi/engine/world.py
@@ -80,7 +80,7 @@ class World(object):
     return collections.OrderedDict(coll)
 
   def find_by_cls(self, cls):
-    return next(self.find_all_by_cls(dt))
+    return next(self.find_all_by_cls(cls))
 
   def find_all_by_dt(self, dt):
     coll = [(ehandle, self.find(ehandle)) for ehandle in self.by_dt[dt]]

--- a/skadi/engine/world.py
+++ b/skadi/engine/world.py
@@ -80,14 +80,20 @@ class World(object):
     return collections.OrderedDict(coll)
 
   def find_by_cls(self, cls):
-    return next(self.find_all_by_cls(cls))
+    items = self.find_all_by_cls(cls).items()
+    if not items:
+      return
+    return items[0]
 
   def find_all_by_dt(self, dt):
     coll = [(ehandle, self.find(ehandle)) for ehandle in self.by_dt[dt]]
     return collections.OrderedDict(coll)
 
   def find_by_dt(self, dt):
-    return next(self.find_all_by_dt(dt))
+    items = self.find_all_by_dt(dt).items()
+    if not items:
+      return
+    return items[0]
 
   def fetch_cls(self, ehandle):
     return self.classes[ehandle]

--- a/skadi/engine/world.py
+++ b/skadi/engine/world.py
@@ -80,20 +80,20 @@ class World(object):
     return collections.OrderedDict(coll)
 
   def find_by_cls(self, cls):
-    items = self.find_all_by_cls(cls).items()
-    if not items:
-      return
-    return items[0]
+    try:
+      return next(self.find_all_by_cls(cls).iteritems())
+    except StopIteration:
+      raise KeyError(cls)
 
   def find_all_by_dt(self, dt):
     coll = [(ehandle, self.find(ehandle)) for ehandle in self.by_dt[dt]]
     return collections.OrderedDict(coll)
 
   def find_by_dt(self, dt):
-    items = self.find_all_by_dt(dt).items()
-    if not items:
-      return
-    return items[0]
+    try:
+      return next(self.find_all_by_dt(dt).iteritems())
+    except StopIteration:
+      raise KeyError(dt)
 
   def fetch_cls(self, ehandle):
     return self.classes[ehandle]


### PR DESCRIPTION
Previously, the `find_by_*` methods were just broken. This pull request simply fixes them. I wasn't sure if I should return `None` or raise an exception when the item was found, but I guess `None` is less intrusive than throwing random exceptions.
