### PR TITLE
Fixing SendTable.baseclass using an invalid filter reference

### DIFF
--- a/skadi/engine/dt/send.py
+++ b/skadi/engine/dt/send.py
@@ -1,5 +1,3 @@
-import itertools
-
 from skadi.engine.dt import prop
 
 
@@ -42,8 +40,7 @@ class SendTable(object):
 
   @property
   def baseclass(self):
-    p = next((p for p in self.filter(prop.test_baseclass)), None)
-    return p.dt if p else None
+    return next((p.dt for p in self.props if prop.test_baseclass(p)), None)
 
   @property
   def exclusions(self):


### PR DESCRIPTION
This one I'm not 100% sure on, but I'm pretty sure `self.filter` here is incorrect, since `SendTable` has no `filter` method

I think my changes are equivalent to what was intended
