### PR TITLE
Python's object does not have __getattr__ only __getattribute__

### DIFF
--- a/skadi/engine/dt/prop.py
+++ b/skadi/engine/dt/prop.py
@@ -43,7 +43,7 @@ class Prop(object):
     if name in Prop.DELEGATED:
       return self._attributes[name]
     else:
-      return object.__getattr__(self, name)
+      return object.__getattribute__(self, name)
 
   def __repr__(self):
     odt, vn, t = self.origin_dt, self.var_name, self._type()


### PR DESCRIPTION
Title says it all, pretty much. I've never been quite sure on the difference in semantics between `__getattr__` and `__getattribute__`, but it seems to be this; `__getattr__` is called when the property cannot be found by standard means (i.e. looking in `__dict__` and friends), whereas `__getattribute__` is called always. Anyway, object doesn't have `__getattr__`, but it does have `__getattribute__`, and the change of semantics don't make a difference here, so this patch just fixes a crash.

http://docs.python.org/2/reference/datamodel.html#object.__getattribute__ for documentation on the difference
