### PR TITLE
bin/skadi: Created custom help output with optparse. Added a check for args (with a...

### DIFF
--- a/bin/skadi
+++ b/bin/skadi
@@ -11,9 +11,12 @@ sys.path.append(root)
 
 from skadi import demo as d
 
-
-option_parser = optparse.OptionParser()
+usage = "skadi [FILE] \n\nExample: 'bin/%prog tests/data/test.dem'"
+option_parser = optparse.OptionParser(usage = usage)
 (options, args) = option_parser.parse_args()
+
+if len(args) < 1:
+    print "No arguments provided.  Run skadi -h for example usage."
 
 for abspath in args:
   print 'opening {0}...'.format(os.path.basename(abspath))


### PR DESCRIPTION
I wanted to make the example script a bit more user friendly.

This adds a bit more info to the default --help screen that optparse provides, and checks to make sure arguments are provided before running.
