### PR TITLE
Fixed error with entries_by_cls entries being overwritten

### DIFF
--- a/skadi/state/collection/entities.py
+++ b/skadi/state/collection/entities.py
@@ -81,7 +81,7 @@ class EntitiesCollection(object):
 
             for _, entry in self.entry_by_index.items():
                 pvs, entity = entry
-                _entries_by_cls[entity.cls] = entry
+                _entries_by_cls[entity.cls].append(entry)
 
             self._entries_by_cls = _entries_by_cls
 

--- a/skadi_ext/state/collection/entities.pyx
+++ b/skadi_ext/state/collection/entities.pyx
@@ -64,7 +64,7 @@ cdef class EntitiesCollection(object):
             if not self._entries_by_cls:
                 for _, entry in self.entry_by_index.items():
                     pvs, entity = entry
-                    _entries_by_cls[entity.cls] = entry
+                    _entries_by_cls[entity.cls].append(entry)
 
                 self._entries_by_cls = _entries_by_cls
 


### PR DESCRIPTION
So entities_by_cls should be a map from cls to a list of entities, and the type is a defaultdict(list), however, the entries were being overridden, instead of being appended to
